### PR TITLE
Skip live-API tests by default in the Stop hook

### DIFF
--- a/.claude/hooks/verify-before-stop.sh
+++ b/.claude/hooks/verify-before-stop.sh
@@ -9,21 +9,26 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Two verification speeds: "full" (default) runs all four tiers; "light" stops after
-# analyze, for quick iteration/live-debugging where a multi-minute build every turn
-# is too much. Claude opts into light mode for a single upcoming turn by running
-# `mkdir -p .claude && echo light > .claude/.verify-level` before finishing — see
-# CLAUDE.md. The marker is one-shot: read once here, then removed, so the next turn
-# defaults back to full unless explicitly set again.
+# Three verification speeds: "light" stops after analyze, for quick iteration/
+# live-debugging where even a build is too much; "full" (default) additionally runs
+# offline tests and the debug APK build; "live" additionally runs the tier-4b live-API
+# coverage suite, which hits a real school over the network (S3 attachment downloads,
+# multi-week timetable/exam/homework crawl) and dominates runtime (~110s vs ~30s for
+# everything else combined) — never run in CI, so it's opt-in here too. Claude opts
+# into a non-default level for a single upcoming turn by running
+# `mkdir -p .claude && echo light > .claude/.verify-level` (or `echo live > ...`)
+# before finishing — see CLAUDE.md. The marker is one-shot: read once here, then
+# removed, so the next turn defaults back to full unless explicitly set again.
 LEVEL_FILE=".claude/.verify-level"
 LEVEL="full"
 if [ -f "$LEVEL_FILE" ]; then
   LEVEL="$(tr -d '[:space:]' < "$LEVEL_FILE")"
   rm -f "$LEVEL_FILE"
 fi
-if [ "$LEVEL" != "light" ]; then
-  LEVEL="full"
-fi
+case "$LEVEL" in
+  light|live) ;;
+  *) LEVEL="full" ;;
+esac
 
 # Tier 2 (codegen) first, since analyze/build/test are meaningless against
 # stale/missing .g.dart/.freezed.dart files.
@@ -52,15 +57,18 @@ if ! flutter test > /tmp/test.log 2>&1; then
   exit 2
 fi
 
-# Tier 4b: live API coverage tests. --run-skipped overrides dart_test.yaml's
+# Tier 4b: live API coverage tests. Opt-in only (LEVEL=live) — see comment above on
+# why this isn't part of the "full" default. --run-skipped overrides dart_test.yaml's
 # always-skip for the 'live' tag; --tags=live still means "only these". Local-only
 # by construction (this hook only ever runs on this machine, never in CI) and safe to
 # run without credentials configured — see test/live/README.md — it then just runs a
 # trivial placeholder test instead of failing.
-if ! flutter test --tags=live --run-skipped > /tmp/test-live.log 2>&1; then
-  echo "flutter test --tags=live found failures. Fix them before finishing:" >&2
-  tail -n 80 /tmp/test-live.log >&2
-  exit 2
+if [ "$LEVEL" = "live" ]; then
+  if ! flutter test --tags=live --run-skipped > /tmp/test-live.log 2>&1; then
+    echo "flutter test --tags=live found failures. Fix them before finishing:" >&2
+    tail -n 80 /tmp/test-live.log >&2
+    exit 2
+  fi
 fi
 
 # Tier 3: build. Debug + single ABI — release would fail without a local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,20 +68,25 @@ This repo has a four-tier verification pipeline (static analysis, codegen, build
 workflow on every PR (tiers 1–3 + offline tests only — never the live-API tier), and a Claude Code
 `Stop` hook (`.claude/hooks/verify-before-stop.sh`) that runs before you can finish a turn.
 
-The hook runs at one of two speeds:
+The hook runs at one of three speeds:
 
-- **full** (default): codegen → analyze → offline tests → live API tests → debug APK build. The
-  live-API step is safe by default even without credentials configured — see
-  `test/live/README.md` — it just runs a trivial placeholder test in that case.
+- **full** (default): codegen → analyze → offline tests → debug APK build (~30s total). Covers
+  everything CI covers.
 - **light**: codegen → analyze only. Use this for small, exploratory, or live-debugging turns where
-  a multi-minute build isn't worth paying for — a single-file fix, iterating on one function, a
-  quick config tweak. For anything that changes behavior more substantially — new
-  models/providers/screens, anything touching the request/parsing layer, multi-file changes — leave
-  it on the default `full` speed so the build and test suite actually run.
+  even a build isn't worth paying for — a single-file fix, iterating on one function, a quick config
+  tweak. For anything that changes behavior more substantially — new models/providers/screens,
+  anything touching the request/parsing layer, multi-file changes — leave it on the default `full`
+  speed so the build and test suite actually run.
+- **live**: everything in `full`, plus the tier-4b live-API coverage suite
+  (`flutter test --tags=live --run-skipped`), which crawls a real school over the network (message
+  attachments, multi-week timetable/exam/homework data) and dominates runtime (~110s on top of
+  `full`'s ~30s) whenever `test/live/credentials.local.json` is configured — see
+  `test/live/README.md`. Never run in CI, and not run by default in the hook either; opt in only
+  when you've touched the request/parsing layer and want to confirm against the real API surface.
 
-To opt into light mode for the *next* Stop only, run this before finishing:
+To opt into a non-default level for the *next* Stop only, run this before finishing:
 ```shell
-mkdir -p .claude && echo light > .claude/.verify-level
+mkdir -p .claude && echo light > .claude/.verify-level   # or: echo live > .claude/.verify-level
 ```
 This is one-shot: the hook deletes the marker after reading it, so the following turn defaults back
 to `full` unless you set it again. When in doubt, do nothing — `full` is the safe default.


### PR DESCRIPTION
## Summary
- The tier-4b live-API coverage suite (`test/live/`) dominated the Stop hook's runtime once real credentials were configured — ~110s of ~140s total, hitting a real school's API on every single turn (message attachment downloads, multi-week timetable/exam/homework crawl).
- It's never run in CI either, so there's no reason for it to be in the hook's default path.
- Adds a third opt-in `live` verify level alongside the existing `light`/`full`, so the live crawl only runs when explicitly requested via `echo live > .claude/.verify-level`.
- Default `full` level is now codegen → analyze → offline tests → debug build (~30s), matching CI's coverage.

## Test plan
- [x] `bash -n .claude/hooks/verify-before-stop.sh` — syntax check
- [x] Manually timed each tier to confirm the live-API suite was the bottleneck (~109s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)